### PR TITLE
Add smooth transition in contact icons

### DIFF
--- a/src/components/icons/Email.astro
+++ b/src/components/icons/Email.astro
@@ -1,6 +1,6 @@
 <svg
 							xmlns="http://www.w3.org/2000/svg"
-							class="size-7 hover:size-8"
+							class="size-7 hover:scale-110 transition-transform"
 							viewBox="0 0 24 24"
 							fill="none"
 							stroke="currentColor"

--- a/src/components/icons/GitHub.astro
+++ b/src/components/icons/GitHub.astro
@@ -1,6 +1,6 @@
 <svg
 							xmlns="http://www.w3.org/2000/svg"
-							class="size-7 hover:size-8"
+							class="size-7 hover:scale-110 transition-transform"
 							viewBox="0 0 24 24"
 							fill="none"
 							stroke="currentColor"

--- a/src/components/icons/Linkedin.astro
+++ b/src/components/icons/Linkedin.astro
@@ -1,6 +1,6 @@
 <svg
 							xmlns="http://www.w3.org/2000/svg"
-							class="size-7 hover:size-8"
+							class="size-7 hover:scale-110 transition-transform"
 							viewBox="0 0 24 24"
 							fill="none"
 							stroke="currentColor"


### PR DESCRIPTION
# Added smooth transition in contact icons via scale property instead of size

now adjacent icons do not jump in the layout when hovering on another

- [x] GitHub icon
- [x] LinkedIn icon
- [x] E-Mail icon

## Before
[before-icons.webm](https://github.com/jsolano0112/portfolio/assets/101495220/2d2f345a-da4e-418a-95c9-2314c612c0e3)

## After
[after-icons.webm](https://github.com/jsolano0112/portfolio/assets/101495220/04dfdda9-1fc3-45c3-b4a2-5998723ea57f)


